### PR TITLE
feat(api): Quarkus /healthz endpoint (#8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.desktop/java.awt.font=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
@@ -106,6 +107,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.desktop/java.awt.font=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/src/main/java/com/aurenworks/api/HealthzResource.java
+++ b/src/main/java/com/aurenworks/api/HealthzResource.java
@@ -1,0 +1,26 @@
+package com.aurenworks.api;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Path("/healthz")
+public class HealthzResource {
+
+  private static final Instant START = Instant.now();
+  private static final String COMMIT_SHA = System.getenv("COMMIT_SHA");
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, Object> health() {
+    Map<String, Object> m = new HashMap<>();
+    m.put("status", "ok");
+    m.put("uptime", (double) (Instant.now().getEpochSecond() - START.getEpochSecond()));
+    m.put("commitSha", COMMIT_SHA == null ? null : COMMIT_SHA);
+    return m;
+  }
+}

--- a/src/test/java/com/aurenworks/api/HealthzResourceTest.java
+++ b/src/test/java/com/aurenworks/api/HealthzResourceTest.java
@@ -1,0 +1,16 @@
+package com.aurenworks.api;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class HealthzResourceTest {
+
+  @Test
+  void healthz_returns_ok() {
+    given().when().get("/healthz").then().statusCode(200).body("status", is("ok")).body("uptime",
+        greaterThanOrEqualTo(0f));
+  }
+}


### PR DESCRIPTION
## What
- Add GET /healthz endpoint in Quarkus REST API
- Return {status, uptime, commitSha} for basic health check

## Why
- Provide a standard health check endpoint for Kubernetes readiness and monitoring

## Testing
- [x] Unit
- [x] Manual
- [ ] Screenshots (if UI)

## Links
- Closes #8