### PR TITLE
feat(api): AuthN/Z scaffolding (#2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/aurenworks/api/ApiExceptionMapper.java
+++ b/src/main/java/com/aurenworks/api/ApiExceptionMapper.java
@@ -1,0 +1,26 @@
+package com.aurenworks.api;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.Map;
+import java.util.UUID;
+
+@Provider
+@ApplicationScoped
+public class ApiExceptionMapper implements ExceptionMapper<Throwable> {
+
+  @Override
+  public Response toResponse(Throwable ex) {
+    // simple requestId for now; later pull from MDC/context
+    String requestId = UUID.randomUUID().toString();
+    int status = (ex instanceof UnsupportedOperationException) ? 501 : 500;
+    String code = (status == 501) ? "NOT_IMPLEMENTED" : "INTERNAL";
+    String message = (status == 501) ? "Not implemented" : "Internal server error";
+
+    ErrorEnvelope body = ErrorEnvelope.of(code, message, Map.of("exception", ex.getClass().getSimpleName()), requestId);
+    return Response.status(status).type(MediaType.APPLICATION_JSON_TYPE).entity(body).build();
+  }
+}

--- a/src/main/java/com/aurenworks/api/AuthResource.java
+++ b/src/main/java/com/aurenworks/api/AuthResource.java
@@ -1,0 +1,48 @@
+package com.aurenworks.api;
+
+import java.util.Map;
+
+import com.aurenworks.api.dto.LoginRequest;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/auth")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AuthResource {
+
+  @POST
+  @Path("/login")
+  public Response login(LoginRequest req) {
+    // scaffold only
+    throw new UnsupportedOperationException("login stub");
+  }
+
+  @POST
+  @Path("/refresh")
+  public Response refresh(Map<String, String> body) {
+    // scaffold only
+    throw new UnsupportedOperationException("refresh stub");
+  }
+
+  @POST
+  @Path("/logout")
+  @Consumes(MediaType.WILDCARD)
+  public Response logout() {
+    // for scaffolding we can return 204 to show endpoint exists
+    return Response.noContent().build();
+  }
+
+  @GET
+  @Path("/me")
+  public Response me() {
+    // scaffold only
+    throw new UnsupportedOperationException("me stub");
+  }
+}

--- a/src/main/java/com/aurenworks/api/ErrorEnvelope.java
+++ b/src/main/java/com/aurenworks/api/ErrorEnvelope.java
@@ -1,0 +1,12 @@
+package com.aurenworks.api;
+
+import java.util.Map;
+
+public record ErrorEnvelope(ErrorInfo error) {
+  public record ErrorInfo(String code, String message, Map<String, Object> details, String requestId) {
+  }
+
+  public static ErrorEnvelope of(String code, String message, Map<String, Object> details, String requestId) {
+    return new ErrorEnvelope(new ErrorInfo(code, message, details, requestId));
+  }
+}

--- a/src/main/java/com/aurenworks/api/dto/LoginRequest.java
+++ b/src/main/java/com/aurenworks/api/dto/LoginRequest.java
@@ -1,0 +1,6 @@
+package com.aurenworks.api.dto;
+
+public class LoginRequest {
+  public String username;
+  public String password;
+}

--- a/src/main/java/com/aurenworks/model/Role.java
+++ b/src/main/java/com/aurenworks/model/Role.java
@@ -1,0 +1,5 @@
+package com.aurenworks.model;
+
+public enum Role {
+  OWNER, BUILDER, VIEWER
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 quarkus.http.port=8080
+
+# Security placeholders (no real provider wired yet)
+# quarkus.oidc.auth-server-url=
+# quarkus.oidc.client-id=
+# quarkus.oidc.credentials.secret=
+# quarkus.smallrye-jwt.enabled=true

--- a/src/test/java/com/aurenworks/api/AuthResourceTest.java
+++ b/src/test/java/com/aurenworks/api/AuthResourceTest.java
@@ -1,0 +1,28 @@
+package com.aurenworks.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class AuthResourceTest {
+
+  @Test
+  void login_is_stubbed_501() {
+    given().contentType("application/json").body("{\"username\":\"u\",\"password\":\"p\"}").when().post("/auth/login")
+        .then().statusCode(501).body("error.code", is("NOT_IMPLEMENTED"));
+  }
+
+  @Test
+  void me_is_stubbed_501() {
+    given().when().get("/auth/me").then().statusCode(501).body("error.code", is("NOT_IMPLEMENTED"));
+  }
+
+  @Test
+  void logout_returns_204() {
+    given().when().post("/auth/logout").then().statusCode(204);
+  }
+}


### PR DESCRIPTION
## What
- Add Auth resource with stub endpoints: POST /auth/login, /auth/refresh, /auth/logout, GET /auth/me
- Add error envelope + global ExceptionMapper
- Add Role enum and LoginRequest DTO

## Why
- Establish authenticated endpoints and error model scaffolding to unblock future JWT/OIDC work

## Testing
- [x] Unit
- [x] Manual
- [ ] Screenshots (if UI)

## Links
- Closes #2

Parent: aurenworks/aurenworks#1

Parent: aurenworks/aurenworks#1
Closes #2
